### PR TITLE
Update to fix issue with "shouldInstallBeta" and "getItemDownloadLocation" methods

### DIFF
--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -375,7 +375,8 @@ def prefPkgInstall() {
 	if (state.mainMenu)
 		return prefOptions()
 	logDebug "prefPkgInstall"
-
+    app.updateSetting("installBeta", false)
+    
 	return dynamicPage(name: "prefPkgInstall", title: "", install: true, uninstall: false) {
 		displayHeader(' Install')
 		section {

--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -1667,8 +1667,7 @@ def performUpdateCheck() {
 	packagesWithUpdates = [:]
 
 	for (pkg in state.manifests) {
-		try 
-        {
+		try {
 			setBackgroundStatusMessage("Checking for updates for ${state.manifests[pkg.key].packageName}")
 			def manifest = getJSONFile(pkg.key)
 			if (shouldInstallBeta(manifest)) {

--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -1667,7 +1667,8 @@ def performUpdateCheck() {
 	packagesWithUpdates = [:]
 
 	for (pkg in state.manifests) {
-		try {
+		try 
+        {
 			setBackgroundStatusMessage("Checking for updates for ${state.manifests[pkg.key].packageName}")
 			def manifest = getJSONFile(pkg.key)
 			if (shouldInstallBeta(manifest)) {
@@ -1691,13 +1692,13 @@ def performUpdateCheck() {
 				log.warn "New version of ${manifest.packageName} found but requires ${manifest.minimumHEVersion}, please update your firmware to upgrade."
 				continue
 			}
-			def includeBetas = pkgBetaOn?.contains(state.manifests[pkg.key].packageName)
-			def newVersionResult = newVersionAvailable(manifest, state.manifests[pkg.key], includeBetas)
+			def betaSelected = pkgBetaOn?.contains(state.manifests[pkg.key].packageName)
+			def newVersionResult = newVersionAvailable(manifest, state.manifests[pkg.key], betaSelected)
 			if (newVersionResult.newVersion) {
-				def version = pkgBetaOn?.contains(state.manifests[pkg.key].packageName) && manifest.betaVersion != null ? manifest.betaVersion : manifest.version
+				def version = betaSelected && manifest.betaVersion != null ? manifest.betaVersion : manifest.version
 				packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (installed: ${state.manifests[pkg.key].version ?: "N/A"} current: ${version})"]
 				logDebug "Updates found for package ${pkg.key}"
-				def notes = (pkgBetaOn?.contains(state.manifests[pkg.key].packageName) && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
 				addUpdateDetails(pkg.key, manifest.packageName, notes, "package", null, newVersionResult.forceProduction)
 			}
 			else {
@@ -1707,13 +1708,13 @@ def performUpdateCheck() {
 						if (app.id) {  // skip if an app is not actually defined
 							def installedApp = getAppById(state.manifests[pkg.key], app.id)
 							if (app?.version != null && installedApp?.version != null) {
-								newVersionResult = newVersionAvailable(app, installedApp, includeBetas)
+								newVersionResult = newVersionAvailable(app, installedApp, betaSelected)
 								if (newVersionResult.newVersion) {
 									if (!appOrDriverNeedsUpdate) { // Only add a package to the list once
 										packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (driver or app has a new version)"]
 									}
 									appOrDriverNeedsUpdate = true
-                              				def notes = (pkgBetaOn?.contains(state.manifests[pkg.key].packageName) && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                              				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                               				addUpdateDetails(pkg.key, manifest.packageName, notes, "specificapp", app, newVersionResult.forceProduction)
 								}
 							}
@@ -1722,7 +1723,7 @@ def performUpdateCheck() {
 									packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (driver or app has a new requirement)"]
 								}
 								appOrDriverNeedsUpdate = true
-                  					def notes = (pkgBetaOn?.contains(state.manifests[pkg.key].packageName) && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                  					def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                   					addUpdateDetails(pkg.key, manifest.packageName, notes, "reqapp", app, newVersionResult.forceProduction)
 							}
 							else if (!installedApp && !app.required) {
@@ -1730,7 +1731,7 @@ def performUpdateCheck() {
 									packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (new optional app or driver is available)"]
 								}
 								appOrDriverNeedsUpdate = true
-                        				def notes = (pkgBetaOn?.contains(state.manifests[pkg.key].packageName) && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                        				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                         				addUpdateDetails(pkg.key, manifest.packageName, notes, "optapp", app, newVersionResult.forceProduction)
 							}
 						}
@@ -1744,13 +1745,13 @@ def performUpdateCheck() {
 						if (driver.id) {  // skip if a driver is not actually defined
 							def installedDriver = getDriverById(state.manifests[pkg.key], driver.id)
 							if (driver?.version != null && installedDriver?.version != null) {
-								newVersionResult = newVersionAvailable(driver, installedDriver, includeBetas)
+								newVersionResult = newVersionAvailable(driver, installedDriver, betaSelected)
 								if (newVersionResult.newVersion) {
 									if (!appOrDriverNeedsUpdate) {// Only add a package to the list once
 										packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (driver or app has a new version)"]
 									}
 									appOrDriverNeedsUpdate = true
-                        					def notes = (includeBetas && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                        					def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                         					addUpdateDetails(pkg.key, manifest.packageName, notes, "specificdriver", driver, newVersionResult.forceProduction)
 								}
 							}
@@ -1759,11 +1760,11 @@ def performUpdateCheck() {
 									packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (driver or app has a new requirement)"]
 								}
 								appOrDriverNeedsUpdate = true
-                        				def notes = (includeBetas && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                        				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                         				addUpdateDetails(pkg.key, manifest.packageName, notes, "reqdriver", driver, newVersionResult.forceProduction)
 							}
 							else if (!installedDriver && !driver.required) {
-                        				def notes = (includeBetas && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                        				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                         				addUpdateDetails(pkg.key, manifest.packageName, notes, "optdriver", driver, newVersionResult.forceProduction)
 								if (!appOrDriverNeedsUpdate) { // Only add a package to the list once
 									packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (new optional app or driver is available)"]
@@ -1781,13 +1782,13 @@ def performUpdateCheck() {
 				        if (bundle.id) { // skip if a bundle is not actually defined
 				            def installedBundle = getBundleById(state.manifests[pkg.key], bundle.id)
 				            if (bundle?.version != null && installedBundle?.version != null) {
-							newVersionResult = newVersionAvailable(bundle, installedBundle)
+							newVersionResult = newVersionAvailable(bundle, installedBundle, betaSelected)
 							if (newVersionResult.newVersion) {
 								if (!appOrDriverNeedsUpdate) {// Only add a package to the list once
 									packagesWithUpdates << ["${pkg.key}": "${state.manifests[pkg.key].packageName} (driver or app has a new version)"]
 								}
 								appOrDriverNeedsUpdate = true
-                        				def notes = (includeBetas && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
+                        				def notes = (betaSelected && manifest.betaReleaseNotes) ? manifest.betaReleaseNotes : manifest.releaseNotes
                         				addUpdateDetails(pkg.key, manifest.packageName, notes, "bundle", bundle, newVersionResult.forceProduction)
 							}
 						} 
@@ -2174,7 +2175,7 @@ def performUpdates(runInBackground) {
 			initializeRollbackState("update")
 
 			manifestForRollback = manifest
-			if (manifest.betaVersion && includeBetas)
+			if (manifest.betaVersion && pkgBetaOn?.contains(state.manifests[pkg.key].packageName))
 				manifest.beta = true
 			for (bundle in manifest.bundles) {
 				def location = getItemDownloadLocation(bundle)

--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -12,7 +12,7 @@
  *    mavrrick v1.9.7   Add ability to individually select apps/packages to include Beta Channels
  *    csteele  v1.9.7    display Release Notes for Installs (prefInstallVerify)
  *    mavrrick v1.9.6	Update to allow separate release notes for Stable and Beta Release
- *				   Updated ability to list installed bundle files from View Apps and Driver Page
+ *				           Updated ability to list installed bundle files from View Apps and Driver Page
  *                         Make Bundles upgradeable on their own
  *    csteele v1.9.5    Take advantage of v2.3.4 deleteHubFile() 
  *    csteele v1.9.4    Take advantage of v2.3.4 uploadHubFile() 

--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -4252,16 +4252,12 @@ def findMatchingAppOrDriver(installedList, item) {
 }
 
 def shouldInstallBeta(item) {
-	if (pkgBetaOn != null) {
-		return item.betaLocation != null && pkgBetaOn.contains(item.name)
-	}
+	return item.betaLocation != null && includeBetas
 }
 
 def getItemDownloadLocation(item) {
-	if (pkgBetaOn != null) {
-		if (item.betaLocation != null && pkgBetaOn.contains(item.name))
-			return item.betaLocation 
-	}
+	if (item.betaLocation != null && includeBetas)
+		return item.betaLocation
 	return item.location
 }
 


### PR DESCRIPTION
A new method was created to facilitate building a list of objects related to bundle selection. 

The "shouldInstallBeta" and "getItemDownloadLocation" methods were updated to use that list to compare with the item being validated. This has corrected the issue for updates. 

The pkgBetaOn selection value has been updated to required to prevent beta being enabled, but nothing being selected. 
