### PR TITLE
Update to support binary type file transfer for files

### DIFF
--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -1,6 +1,6 @@
 /**
  *
- *  Hubitat Package Manager v1.9.9
+ *  Hubitat Package Manager v1.9.10
  *
  *  Copyright 2020 Dominick Meglio
  *
@@ -9,6 +9,7 @@
  *
  *
  *
+ *    mavrrick 1.9.10   Enhanced file processing to allow for a binary file download when new tag is specified and "binary" is used.
  *    csteele  v1.9.9   UpgradeApp() moved to the Top to remediate HPM crashing during Upgrade of itself due to the methods moving post-upgrade.
  *                         Replaced "Fast Search" algorithm to also use fuzzy, thus eliminating the need for two choices. Delete Azure query.
  *                         Created an external Fast-Track Match Up tool. Default on but Optional. 

--- a/apps/Package_Manager.groovy
+++ b/apps/Package_Manager.groovy
@@ -9,7 +9,6 @@
  *
  *
  *
- *    mavrrick 1.9.10   Enhanced file processing to allow for a binary file download when new tag is specified and "binary" is used.
  *    csteele  v1.9.9   UpgradeApp() moved to the Top to remediate HPM crashing during Upgrade of itself due to the methods moving post-upgrade.
  *                         Replaced "Fast Search" algorithm to also use fuzzy, thus eliminating the need for two choices. Delete Azure query.
  *                         Created an external Fast-Track Match Up tool. Default on but Optional. 
@@ -59,7 +58,7 @@
  *                         added feature to identify Azure search vs sql search
  */
 
-	public static String version()      {  return "v1.9.9"  }
+	public static String version()      {  return "v1.9.10"  }
 	def getThisCopyright(){"&copy; 2020 Dominick Meglio"}
 
 definition(
@@ -999,7 +998,7 @@ def performInstallation() {
 	}
 
 	for (fileToInstall in manifest.files) {
-        def txType = fileToInstall.tranferType
+        def txType = fileToInstall.transferType
 		def location = getItemDownloadLocation(fileToInstall)
 		def fileContents = fileManagerFiles[location]
 		setBackgroundStatusMessage("Installing ${location}")
@@ -1540,7 +1539,7 @@ def performRepair() {
 		}
 
 		for (fileToInstall in manifest.files) {
-            def txType = fileToInstall.tranferType
+            def txType = fileToInstall.transferType
 			def location = getItemDownloadLocation(fileToInstall)
 			def fileContents = fileManagerFiles[location]
 			setBackgroundStatusMessage("Installing ${location}")
@@ -2411,7 +2410,7 @@ def performUpdates(runInBackground) {
 			}
 
 			for (fileToInstall in manifest.files) {
-                def txType = fileToInstall.tranferType
+                def txType = fileToInstall.transferType
 				def location = getItemDownloadLocation(fileToInstall)
 				def fileContents = fileManagerFiles[location]
 				setBackgroundStatusMessage("Installing ${location}")
@@ -4465,7 +4464,7 @@ def minimizeStoredManifests() {
 def downloadFileManagerFiles(manifest) {
 	def files = [:]
 	for (fileToInstall in manifest.files) {
-        def txType = fileToInstall.tranferType
+        def txType = fileToInstall.transferType
         logDebug "files to be download are ${fileToInstall}.. Transfer type is ${txType}"
 		def location = getItemDownloadLocation(fileToInstall)
 		setBackgroundStatusMessage("Downloading ${location}")


### PR DESCRIPTION
This is a enhancement for files that are not text based. An alternate path has been created when a file is tagged in the package manifest with transferType of binary. 

When a file is tagged as such it will retrieve the file using a new downloadFileBinary method that uses different headers that direct the data to be handle as binary. The new headers are application/octet-stream. To maintain the binary file format a new InstallFileBinary method was created. This method simply takes the file data stored from the downloadFileBinary method and writes it to internal storage. These new methods maintain the same flow as previously used. 

To facilitate the use of the new methods to handle binary files the existing methods performInstallation, performRepair, and performUpdates were updated to look at the transferType value and use either the legacy installFile, or installFileBinary accordingly. 